### PR TITLE
Build CMake from sources if necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ osx: &osx
 matrix:
    include:
       - <<: *linux
+      - <<: *linux
+        env: CONAN_DOCKER_IMAGE=lasote/conangcc49-i386
       - <<: *osx
         osx_image: xcode9.2
         env: CONAN_CURRENT_PAGE=1 CONAN_TOTAL_PAGES=2

--- a/build.py
+++ b/build.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 from conan.packager import ConanMultiPackager
@@ -12,16 +13,23 @@ if __name__ == "__main__":
 
     builder = ConanMultiPackager()
 
+    i386 = "CONAN_DOCKER_IMAGE" in os.environ and \
+        os.environ["CONAN_DOCKER_IMAGE"].endswith("i386")
+
     # New mode, with version field
     for version in available_versions:
         # Unknown problem with 3.0.2 on travis
-        if version > "3.0.2" or platform.system() == "Windows":
+        # Building from sources takes much time so build the very recent 32bit version only
+        if (version > "3.0.2" and not i386) or platform.system() == "Windows" or \
+                version == available_versions[0]:
             builder.add({}, {}, {}, {}, reference="cmake_installer/%s" % version)
 
     # Old mode, with options
     for version in available_versions:
         # Unknown problem with 3.0.2 on travis
-        if version > "3.0.2" or platform.system() == "Windows":
+        # Building from sources takes much time so build the very recent 32bit version only
+        if (version > "3.0.2" and not i386) or platform.system() == "Windows" or \
+                version == available_versions[0]:
             builder.add({}, {"cmake_installer:version": version}, {}, {}, "cmake_installer/1.0")
 
     builder.run()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,4 +1,4 @@
-import StringIO
+from six import StringIO
 import conans
 
 
@@ -8,7 +8,7 @@ class ConanFileInst(conans.ConanFile):
         pass
 
     def test(self):
-        output = StringIO.StringIO()
+        output = StringIO()
         self.run("cmake --version", output=output)
         self.output.info("Installed: %s" % str(output.getvalue()))
         if self.requires["cmake_installer"].conan_reference.version != "1.0":


### PR DESCRIPTION
Kitware does not distribute i386 binaries for recent CMake versions. Build CMake from sources if the binary is not available. Closes https://github.com/conan-community/conan-cmake-installer/issues/14