### PR TITLE
Force static link for OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(conan_wrapper)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
 message(STATUS "Conan CMake Wrapper")
-
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-# include_directories(${CMAKE_SOURCE_DIR}/source_subfolder)
 add_subdirectory("source_subfolder")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8)
+project(conan_wrapper)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+message(STATUS "Conan CMake Wrapper")
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+# include_directories(${CMAKE_SOURCE_DIR}/source_subfolder)
+add_subdirectory("source_subfolder")

--- a/conanfile.py
+++ b/conanfile.py
@@ -112,8 +112,9 @@ class CMakeInstallerConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["CMAKE_BOOTSTRAP"] = False
-        cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = True
-        cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
+        if self.settings.os_build == "Linux":
+            cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = True
+            cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
         cmake.configure(source_dir=self._source_subfolder)
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -34,7 +34,9 @@ class CMakeInstallerConan(ConanFile):
     settings = "os_build", "arch_build", "compiler", "arch"
     options = {"version": available_versions}
     default_options = {"version": [v for v in available_versions if "-" not in v][0]}
+    generators = "cmake"
     exports = "LICENSE"
+    exports_sources = "CMakeLists.txt"
 
     @property
     def _source_subfolder(self):
@@ -75,6 +77,9 @@ class CMakeInstallerConan(ConanFile):
     def _build_from_source(self):
         return os.path.exists(os.path.join(self.build_folder, self._source_subfolder, "configure"))
 
+    def requirements(self):
+        self.requires("OpenSSL/1.0.2s@conan/stable")
+
     def config_options(self):
         if self.version >= Version("2.8"):  # Means CMake version
             del self.options.version
@@ -107,6 +112,8 @@ class CMakeInstallerConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["CMAKE_BOOTSTRAP"] = False
+        cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = True
+        cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
         cmake.configure(source_dir=self._source_subfolder)
         return cmake
 


### PR DESCRIPTION
To use CMake installer in distros where OpenSSL 1.0.x is not available, as Clang8-x86, where only OpenSSL 1.1.x is installed, we need to link OpenSSL statically to CMake.

The OpenSSL package needs zlib, but CMake uses FindOpenSSL.cmake only, which won't list zlib as a requirement, so I needed to set CMAKE_EXE_LINKER_FLAGS

related issue: https://github.com/conan-community/community/issues/256