### PR TITLE
Updates SSL version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -78,7 +78,7 @@ class CMakeInstallerConan(ConanFile):
         return os.path.exists(os.path.join(self.build_folder, self._source_subfolder, "configure"))
 
     def requirements(self):
-        self.requires("OpenSSL/1.0.2s@conan/stable")
+        self.requires("OpenSSL/1.1.1d@conan/stable")
 
     def config_options(self):
         if self.version >= Version("2.8"):  # Means CMake version


### PR DESCRIPTION
This version conflicts with Qt for example. It is possible to downgrade the Qt version, but as this one is quite old, I think it is better to upgrade the cmake one.