### PR TITLE
Set OpenSSL as private requirement

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -77,8 +77,8 @@ class CMakeInstallerConan(ConanFile):
     def _build_from_source(self):
         return os.path.exists(os.path.join(self.build_folder, self._source_subfolder, "configure"))
 
-    def requirements(self):
-        self.requires("OpenSSL/1.0.2s@conan/stable")
+    def build_requirements(self):
+        self.build_requires("OpenSSL/1.0.2s@conan/stable")
 
     def config_options(self):
         if self.version >= Version("2.8"):  # Means CMake version

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,8 +77,8 @@ class CMakeInstallerConan(ConanFile):
     def _build_from_source(self):
         return os.path.exists(os.path.join(self.build_folder, self._source_subfolder, "configure"))
 
-    def build_requirements(self):
-        self.build_requires("OpenSSL/1.0.2s@conan/stable")
+    def requirements(self):
+        self.requires("OpenSSL/1.0.2s@conan/stable", private=True)
 
     def config_options(self):
         if self.version >= Version("2.8"):  # Means CMake version


### PR DESCRIPTION
As CMake is linking to OpenSSL using the static version only, we should set it as private requirement, otherwise it will affect other packages which are using OpenSSL too.

Related issues:
- https://github.com/conan-community/conan-cmake-installer/pull/32
- https://github.com/conan-community/conan-cmake-installer/pull/31#issuecomment-523013822